### PR TITLE
build: upgrade javadoc plugin to 3.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,10 +289,10 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <plugin>
+                   <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.0.1</version>
+                        <version>3.11.1</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -305,7 +305,10 @@
                         <configuration>
                             <quiet>true</quiet>
                             <doclint>none</doclint>
-                            <additionalparam>-Xdoclint:none</additionalparam>
+                            <failOnWarnings>false</failOnWarnings>
+                            <links>
+                                <link>https://javadoc.io/doc/com.vaadin/vaadin-platform-javadoc/${vaadin.version}</link>
+                            </links>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated plugin versions in the build configuration for improved performance and stability.
	- Enhanced the build process by modifying configurations for various plugins.
	- Added a new profile for GPG signing of artifacts to streamline the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->