### PR TITLE
Fix javadoc warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,7 @@
                         <configuration>
                             <quiet>true</quiet>
                             <doclint>none</doclint>
-                            <failOnWarnings>false</failOnWarnings>
+                            <failOnWarnings>true</failOnWarnings>
                             <links>
                                 <link>https://javadoc.io/doc/com.vaadin/vaadin-platform-javadoc/${vaadin.version}</link>
                             </links>

--- a/src/main/java/com/flowingcode/vaadin/addons/dayofweekselector/DayOfWeekSelector.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/dayofweekselector/DayOfWeekSelector.java
@@ -190,7 +190,6 @@ public class DayOfWeekSelector extends CustomField<Set<DayOfWeek>> {
    * Sets the short names of the week days, starting from {@code sun} and ending on {@code sat}.
    *
    * @param weekdaysShort the short names of the week days
-   * @return this instance for method chaining
    */
   public void setWeekDaysShort(List<String> weekdaysShort) {
     Objects.requireNonNull(weekdaysShort);
@@ -209,8 +208,7 @@ public class DayOfWeekSelector extends CustomField<Set<DayOfWeek>> {
    * 0 for Sunday, 1 for Monday, 2 for Tuesday, 3 for Wednesday, 4 for Thursday, 5 for Friday, 6 for
    * Saturday.
    *
-   * @param firstDayOfWeek the index of the first day of the week
-   * @return this instance for method chaining
+   * @param first the index of the first day of the week
    * @throws IllegalArgumentException if firstDayOfWeek is invalid
    */
   public void setFirstDayOfWeek(DayOfWeek first) {


### PR DESCRIPTION
Close #8 & #10 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced documentation standards for Javadoc generation, ensuring stricter compliance with warnings.
	- Improved parameter naming for better clarity in method signatures of the `DayOfWeekSelector` class.

- **Bug Fixes**
	- Removed misleading return type documentation from the `setWeekDaysShort` method. 

- **Chores**
	- Updated Maven configuration for GPG signing to activate only with a provided passphrase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->