### PR TITLE
Add method to set tooltip for days of week

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.flowingcode.vaadin.addons</groupId>
     <artifactId>day-of-week-selector-addon</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <name>Day of Week Selector Add-on</name>
     <description>Day of Week Selector Add-on for Vaadin Flow</description>
     <url>https://www.flowingcode.com/en/open-source/</url>

--- a/src/main/java/com/flowingcode/vaadin/addons/dayofweekselector/DayOfWeekSelector.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/dayofweekselector/DayOfWeekSelector.java
@@ -178,7 +178,12 @@ public class DayOfWeekSelector extends CustomField<Set<DayOfWeek>> {
    * @param i18n the internationalized properties, not <code>null</code>
    */
   public void setI18N(DatePickerI18n i18n) {
-    setWeekDaysShort(i18n.getWeekdaysShort());
+    if (i18n.getWeekdaysShort() != null) {
+      setWeekDaysShort(i18n.getWeekdaysShort());
+    }
+    if (i18n.getWeekdays() != null) {
+      setWeekDaysTooltip(i18n.getWeekdays());
+    }
     if (i18n.getFirstDayOfWeek() == 0) {
       setFirstDayOfWeek(DayOfWeek.SUNDAY);
     } else {
@@ -199,6 +204,22 @@ public class DayOfWeekSelector extends CustomField<Set<DayOfWeek>> {
       String text = weekdaysShort.get(index);
       getButtons().filter(button -> button.getDayOfWeek() == day)
           .forEach(button -> button.setText(text));
+    }
+  }
+
+  /**
+   * Sets the tooltips of the week days, starting from {@code sun} and ending on {@code sat}.
+   * 
+   * @param weekdaysTooltip the tooltips of the week days
+   */
+  public void setWeekDaysTooltip(List<String> weekdaysTooltip) {
+    Objects.requireNonNull(weekdaysTooltip);
+
+    for (DayOfWeek day : DayOfWeek.values()) {
+      int index = day.getValue() % 7;
+      String text = weekdaysTooltip.get(index);
+      getButtons().filter(button -> button.getDayOfWeek() == day)
+          .forEach(button -> button.setTooltipText(text));
     }
   }
 

--- a/src/test/java/com/flowingcode/vaadin/addons/dayofweekselector/DayOfWeekSelectorI18NDemo.java
+++ b/src/test/java/com/flowingcode/vaadin/addons/dayofweekselector/DayOfWeekSelectorI18NDemo.java
@@ -20,11 +20,14 @@
 package com.flowingcode.vaadin.addons.dayofweekselector;
 
 import com.flowingcode.vaadin.addons.demo.DemoSource;
+import com.vaadin.flow.component.datepicker.DatePicker.DatePickerI18n;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import java.time.DayOfWeek;
+import java.time.format.TextStyle;
 import java.util.List;
+import java.util.stream.Stream;
 
 @DemoSource
 @PageTitle("I18N")
@@ -34,6 +37,21 @@ public class DayOfWeekSelectorI18NDemo extends Div {
 
   public DayOfWeekSelectorI18NDemo() {
     DayOfWeekSelector selector = new DayOfWeekSelector();
+    selector.setLabel("I18N with DatePickerI18n");
+
+    DatePickerI18n i18n = new DatePickerI18n();
+    i18n.setWeekdaysShort(Stream.of(DayOfWeek.values())
+        .map(d -> d.getDisplayName(TextStyle.NARROW_STANDALONE, getLocale())).toList());
+    i18n.setWeekdays(Stream.of(DayOfWeek.values())
+        .map(d -> d.getDisplayName(TextStyle.FULL_STANDALONE, getLocale())).toList());
+    i18n.setFirstDayOfWeek(DayOfWeek.MONDAY.getValue() - 1);
+    selector.setI18N(i18n);
+    add(selector);
+
+    selector = new DayOfWeekSelector();
+    selector.setLabel("I18N without DatePickerI18n");
+    selector.setWeekDaysTooltip(
+        List.of("Domingo", "Lunes", "Martes", "Miércoles", "Jueves", "Viernes", "Sábado"));
     selector.setWeekDaysShort(List.of("D", "L", "M", "X", "J", "V", "S"));
     selector.setFirstDayOfWeek(DayOfWeek.MONDAY);
     add(selector);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the day-of-week selector component with improved internationalization, including localized weekday names and added tooltips for a richer user experience.
	- Updated demo examples now showcase both standard localization and tooltip-enabled options.
- **Chores**
	- Updated the project version to mark the latest release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->